### PR TITLE
Refactor duplication of type into reusable type.

### DIFF
--- a/dist/wpay-1-0-5.json
+++ b/dist/wpay-1-0-5.json
@@ -593,63 +593,8 @@
           "required":true,
           "content":{
             "application/json":{
-              "schema":{
-                "title":"customerPaymentDetails",
-                "type":"object",
-                "required":[
-                  "data",
-                  "meta"
-                ],
-                "properties":{
-                  "data":{
-                    "description":"Mandatory data object containing response",
-                    "type":"object",
-                    "properties":{
-                      "primaryInstrumentId":{
-                        "description":"The Id of the primary instrument.  Will be used as the balance of the transaction.  If not present then the primary instrument from the customer preferences will be used.",
-                        "type":"string"
-                      },
-                      "secondaryInstruments":{
-                        "description":"The secondary instruments (if any) used to partially make the payment.  If not present then the primary instrument from the customer preferences will be used.  To specify that no secondary instruments should be used an empty array should be provided.",
-                        "type":"array",
-                        "items":{
-                          "description":"An instrument used for this transaction",
-                          "type":"object",
-                          "required":[
-                            "instrumentId",
-                            "amount"
-                          ],
-                          "properties":{
-                            "instrumentId":{
-                              "description":"The ID of the payment instrument",
-                              "type":"string"
-                            },
-                            "amount":{
-                              "description":"The amount to charged against this instrument.  Must be greater than zero",
-                              "type":"number",
-                              "minimum":0,
-                              "exclusiveMinimum":true
-                            }
-                          }
-                        }
-                      },
-                      "skipRollback": {
-                        "description": "An optional flag allowing the consumer to indicate that automatic rollback step should be skipped in the case of failure",
-                        "type": "boolean"
-                      },
-                      "clientReference":{
-                        "description":"An optional client reference to be associated with the transaction.  If not suplied the transactionId will be used.",
-                        "type":"string"
-                      },
-                      "preferences": {
-                        "$ref": "#/components/schemas/preferencePayments"
-                      }
-                    }
-                  },
-                  "meta":{
-                    "$ref": "#/components/schemas/meta"
-                  }
-                }
+              "schema": {
+                "$ref":"#/components/schemas/customerPaymentDetails"
               }
             }
           }
@@ -1459,63 +1404,8 @@
           "required":true,
           "content":{
             "application/json":{
-              "schema":{
-                "title":"customerPaymentDetails",
-                "type":"object",
-                "required":[
-                  "data",
-                  "meta"
-                ],
-                "properties":{
-                  "data":{
-                    "description":"Mandatory data object containing response",
-                    "type":"object",
-                    "properties":{
-                      "primaryInstrumentId":{
-                        "description":"The Id of the primary instrument.  Will be used as the balance of the transaction.  If not present then the primary instrument from the customer preferences will be used.",
-                        "type":"string"
-                      },
-                      "secondaryInstruments":{
-                        "description":"The secondary instruments (if any) used to partially make the payment.  If not present then the primary instrument from the customer preferences will be used.  To specify that no secondary instruments should be used an empty array should be provided.",
-                        "type":"array",
-                        "items":{
-                          "description":"An instrument used for this transaction",
-                          "type":"object",
-                          "required":[
-                            "instrumentId",
-                            "amount"
-                          ],
-                          "properties":{
-                            "instrumentId":{
-                              "description":"The ID of the payment instrument",
-                              "type":"string"
-                            },
-                            "amount":{
-                              "description":"The amount to charged against this instrument.  Must be greater than zero",
-                              "type":"number",
-                              "minimum":0,
-                              "exclusiveMinimum":true
-                            }
-                          }
-                        }
-                      },
-                      "skipRollback": {
-                        "description": "An optional flag allowing the consumer to indicate that automatic rollback step should be skipped in the case of failure",
-                        "type": "boolean"
-                      },
-                      "clientReference":{
-                        "description":"An optional client reference to be associated with the transaction.  If not suplied the transactionId will be used.",
-                        "type":"string"
-                      },
-                      "preferences": {
-                        "$ref": "#/components/schemas/preferencePayments"
-                      }
-                    }
-                  },
-                  "meta":{
-                    "$ref":"#/components/schemas/metaChallenge"
-                  }
-                }
+              "schema": {
+                "$ref":"#/components/schemas/customerPaymentDetails"
               }
             }
           }
@@ -20340,6 +20230,63 @@
           "description": {
             "type": "string",
             "description": "A description of the payment agreement"
+          }
+        }
+      },
+      "customerPaymentDetails": {
+        "type":"object",
+        "required":[
+          "data",
+          "meta"
+        ],
+        "properties":{
+          "data":{
+            "description":"Mandatory data object containing response",
+            "type":"object",
+            "properties":{
+              "primaryInstrumentId":{
+                "description":"The Id of the primary instrument.  Will be used as the balance of the transaction.  If not present then the primary instrument from the customer preferences will be used.",
+                "type":"string"
+              },
+              "secondaryInstruments":{
+                "description":"The secondary instruments (if any) used to partially make the payment.  If not present then the primary instrument from the customer preferences will be used.  To specify that no secondary instruments should be used an empty array should be provided.",
+                "type":"array",
+                "items":{
+                  "description":"An instrument used for this transaction",
+                  "type":"object",
+                  "required":[
+                    "instrumentId",
+                    "amount"
+                  ],
+                  "properties":{
+                    "instrumentId":{
+                      "description":"The ID of the payment instrument",
+                      "type":"string"
+                    },
+                    "amount":{
+                      "description":"The amount to charged against this instrument.  Must be greater than zero",
+                      "type":"number",
+                      "minimum":0,
+                      "exclusiveMinimum":true
+                    }
+                  }
+                }
+              },
+              "skipRollback": {
+                "description": "An optional flag allowing the consumer to indicate that automatic rollback step should be skipped in the case of failure",
+                "type": "boolean"
+              },
+              "clientReference":{
+                "description":"An optional client reference to be associated with the transaction.  If not suplied the transactionId will be used.",
+                "type":"string"
+              },
+              "preferences": {
+                "$ref": "#/components/schemas/preferencePayments"
+              }
+            }
+          },
+          "meta":{
+            "$ref": "#/components/schemas/meta"
           }
         }
       }

--- a/src/wpay-1.json
+++ b/src/wpay-1.json
@@ -594,62 +594,7 @@
           "content":{
             "application/json":{
               "schema":{
-                "title":"customerPaymentDetails",
-                "type":"object",
-                "required":[
-                  "data",
-                  "meta"
-                ],
-                "properties":{
-                  "data":{
-                    "description":"Mandatory data object containing response",
-                    "type":"object",
-                    "properties":{
-                      "primaryInstrumentId":{
-                        "description":"The Id of the primary instrument.  Will be used as the balance of the transaction.  If not present then the primary instrument from the customer preferences will be used.",
-                        "type":"string"
-                      },
-                      "secondaryInstruments":{
-                        "description":"The secondary instruments (if any) used to partially make the payment.  If not present then the primary instrument from the customer preferences will be used.  To specify that no secondary instruments should be used an empty array should be provided.",
-                        "type":"array",
-                        "items":{
-                          "description":"An instrument used for this transaction",
-                          "type":"object",
-                          "required":[
-                            "instrumentId",
-                            "amount"
-                          ],
-                          "properties":{
-                            "instrumentId":{
-                              "description":"The ID of the payment instrument",
-                              "type":"string"
-                            },
-                            "amount":{
-                              "description":"The amount to charged against this instrument.  Must be greater than zero",
-                              "type":"number",
-                              "minimum":0,
-                              "exclusiveMinimum":true
-                            }
-                          }
-                        }
-                      },
-                      "skipRollback": {
-                        "description": "An optional flag allowing the consumer to indicate that automatic rollback step should be skipped in the case of failure",
-                        "type": "boolean"
-                      },
-                      "clientReference":{
-                        "description":"An optional client reference to be associated with the transaction.  If not suplied the transactionId will be used.",
-                        "type":"string"
-                      },
-                      "preferences": {
-                        "$ref": "#/components/schemas/preferencePayments"
-                      }
-                    }
-                  },
-                  "meta":{
-                    "$ref": "#/components/schemas/meta"
-                  }
-                }
+                "$ref":"#/components/schemas/customerPaymentDetails"
               }
             }
           }
@@ -1460,62 +1405,7 @@
           "content":{
             "application/json":{
               "schema":{
-                "title":"customerPaymentDetails",
-                "type":"object",
-                "required":[
-                  "data",
-                  "meta"
-                ],
-                "properties":{
-                  "data":{
-                    "description":"Mandatory data object containing response",
-                    "type":"object",
-                    "properties":{
-                      "primaryInstrumentId":{
-                        "description":"The Id of the primary instrument.  Will be used as the balance of the transaction.  If not present then the primary instrument from the customer preferences will be used.",
-                        "type":"string"
-                      },
-                      "secondaryInstruments":{
-                        "description":"The secondary instruments (if any) used to partially make the payment.  If not present then the primary instrument from the customer preferences will be used.  To specify that no secondary instruments should be used an empty array should be provided.",
-                        "type":"array",
-                        "items":{
-                          "description":"An instrument used for this transaction",
-                          "type":"object",
-                          "required":[
-                            "instrumentId",
-                            "amount"
-                          ],
-                          "properties":{
-                            "instrumentId":{
-                              "description":"The ID of the payment instrument",
-                              "type":"string"
-                            },
-                            "amount":{
-                              "description":"The amount to charged against this instrument.  Must be greater than zero",
-                              "type":"number",
-                              "minimum":0,
-                              "exclusiveMinimum":true
-                            }
-                          }
-                        }
-                      },
-                      "skipRollback": {
-                        "description": "An optional flag allowing the consumer to indicate that automatic rollback step should be skipped in the case of failure",
-                        "type": "boolean"
-                      },
-                      "clientReference":{
-                        "description":"An optional client reference to be associated with the transaction.  If not suplied the transactionId will be used.",
-                        "type":"string"
-                      },
-                      "preferences": {
-                        "$ref": "#/components/schemas/preferencePayments"
-                      }
-                    }
-                  },
-                  "meta":{
-                    "$ref":"#/components/schemas/metaChallenge"
-                  }
-                }
+                "$ref":"#/components/schemas/customerPaymentDetails"
               }
             }
           }
@@ -20340,6 +20230,63 @@
           "description": {
             "type": "string",
             "description": "A description of the payment agreement"
+          }
+        }
+      },
+      "customerPaymentDetails": {
+        "type":"object",
+        "required":[
+          "data",
+          "meta"
+        ],
+        "properties":{
+          "data":{
+            "description":"Mandatory data object containing response",
+            "type":"object",
+            "properties":{
+              "primaryInstrumentId":{
+                "description":"The Id of the primary instrument.  Will be used as the balance of the transaction.  If not present then the primary instrument from the customer preferences will be used.",
+                "type":"string"
+              },
+              "secondaryInstruments":{
+                "description":"The secondary instruments (if any) used to partially make the payment.  If not present then the primary instrument from the customer preferences will be used.  To specify that no secondary instruments should be used an empty array should be provided.",
+                "type":"array",
+                "items":{
+                  "description":"An instrument used for this transaction",
+                  "type":"object",
+                  "required":[
+                    "instrumentId",
+                    "amount"
+                  ],
+                  "properties":{
+                    "instrumentId":{
+                      "description":"The ID of the payment instrument",
+                      "type":"string"
+                    },
+                    "amount":{
+                      "description":"The amount to charged against this instrument.  Must be greater than zero",
+                      "type":"number",
+                      "minimum":0,
+                      "exclusiveMinimum":true
+                    }
+                  }
+                }
+              },
+              "skipRollback": {
+                "description": "An optional flag allowing the consumer to indicate that automatic rollback step should be skipped in the case of failure",
+                "type": "boolean"
+              },
+              "clientReference":{
+                "description":"An optional client reference to be associated with the transaction.  If not suplied the transactionId will be used.",
+                "type":"string"
+              },
+              "preferences": {
+                "$ref": "#/components/schemas/preferencePayments"
+              }
+            }
+          },
+          "meta":{
+            "$ref": "#/components/schemas/meta"
           }
         }
       }


### PR DESCRIPTION
Fixes #2 

Because this is a refactoring, there's no need for a new version of the spec. This is why I have updated both the `src` and the `dist` copies.